### PR TITLE
Fixing overflow when app viewed on mobile

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -47,6 +47,12 @@ body {
   background-color: rgb(240, 240, 240);
 }
 
+@media (max-width:801px) {
+  body {
+    overflow-x: hidden !important;
+  }
+}
+
 .pageContent {
   width: 100%;
   margin-left: auto;


### PR DESCRIPTION
App moves from left to right when viewed on mobile browser. Media query added to body tag to try and prevent this from happening