### PR TITLE
CSS changes and change to location of "view all" button

### DIFF
--- a/src/app/css/card-structure.component.css
+++ b/src/app/css/card-structure.component.css
@@ -6,7 +6,7 @@
 
 @media (max-width: 1110px) {
     .list-wrapper {
-        padding: 0px 0 10px 0;
+        padding: 0 0 4rem 0;
     }
 }
 
@@ -36,6 +36,7 @@
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: left;
+    position: relative;
 }
 
 @media (max-width: 1110px) {

--- a/src/app/css/main-structure.component.css
+++ b/src/app/css/main-structure.component.css
@@ -2,7 +2,6 @@
     max-width: 100%;
     background-color: white;
     color:  rgb(65, 65, 65);
-    /*box-shadow: 0 1px 6px 0 hsla(0, 0%, 0%, 0.3);*/
 }
 
 .heroContainer {
@@ -81,10 +80,11 @@
     outline: none;
     margin-left: 31%;
     letter-spacing: 0.2rem;
+
 }
 
 .viewAll-button {
-    margin-top: 0.5rem;
+    margin-top: 1.5rem;
     padding: 0 0 0 1rem;
     border-left: 0.3rem solid #0193B7;
     color: rgb(65, 65, 65);
@@ -97,7 +97,13 @@
     outline: none;
     transition: box-shadow 0.2s ease;
     letter-spacing: 0.2rem;
-  }
+}
+
+@media (max-width: 1110px) {
+    .viewAll-button {
+        margin-left: 1rem;
+    }
+}
 
 @media (max-width: 638px) {
     .heroLogo {

--- a/src/app/main/live-stream/live-stream.component.css
+++ b/src/app/main/live-stream/live-stream.component.css
@@ -43,10 +43,6 @@
     .youTubeEmbed {
         width: 100%;
     }
-
-    .youTube-vid-text {
-        padding: 0 0 1rem 1rem;
-    }
 }
 
 .youTube-vid-text {
@@ -58,7 +54,13 @@
     padding: 0;
     box-shadow: 0 0.1rem 0.6rem 0 hsla(0, 0%, 0%, 0.3);
     border-radius: 0.5rem;
+}
 
+@media (max-width: 1422px) {
+    .youTube-vid-text {
+        flex-basis: 100%;
+        margin-top: 2rem;
+    }
 }
 
 .youTube-vid-text h3 {
@@ -79,8 +81,7 @@
 
 @media (max-width: 801px) {
     .youTube-vid-text {
-        flex-basis: 100%;
-        padding: 1rem;
+        padding-bottom: 1.5rem;
     }
 
     .youTube-vid-text p {

--- a/src/app/music/mainComponent/live-stream-archive/live-stream-archive.component.css
+++ b/src/app/music/mainComponent/live-stream-archive/live-stream-archive.component.css
@@ -3,9 +3,22 @@
     overflow-y: hidden;
 }
 
+@media (max-width: 1110px) {
+    .live-stream-wrapper {
+        margin: 1rem;
+    }
+}
+
 .live-stream-wrapper-expanded {
     max-width: 100%;
+    margin: auto;
     overflow-y: hidden;
+}
+
+@media (max-width: 1110px) {
+    .live-stream-wrapper-expanded {
+        max-width: 98.3%;
+    }
 }
 
 .live-stream-container {
@@ -20,8 +33,9 @@
 }
 
 @media (max-width: 1110px) {
-    .live-stream-wrapper {
-        margin: 1rem;
+    .live-stream-container {
+        margin-left: 0.2rem;
+        margin-right: 0.2rem;
     }
 }
 
@@ -47,6 +61,8 @@
 
     .youTubeEmbed {
         width: 100%;
+        border-top-right-radius: 0.5rem;
+        border-bottom-left-radius: 0rem;
     }
 
     .youTube-vid-text {
@@ -88,6 +104,13 @@
     transition: box-shadow 0.2s ease;
     letter-spacing: 0.2rem;
     margin: 1rem 2rem 2rem 2rem;
+}
+
+
+@media (max-width: 1110px) {
+    .viewAll-button {
+        margin-left: 1rem;
+    }
 }
 
 .element-wrapper {

--- a/src/app/music/mainComponent/podcast-tile/podcast-tile.component.html
+++ b/src/app/music/mainComponent/podcast-tile/podcast-tile.component.html
@@ -5,8 +5,7 @@
         <div class="cardElement" *ngFor="let podcast of podcasts | slice:0:4; let i=index">
             <podcast-tile-thumbnail [podcast]="podcast"></podcast-tile-thumbnail>
         </div>
-        
-        <span class="viewAll-button" (click)="viewPodcasts()" [innerHTML]="musicContent.button2"></span>
+    
     </div>
-
+    <span class="viewAll-button" (click)="viewPodcasts()" [innerHTML]="musicContent.button2"></span>
 </div>

--- a/src/app/music/mainComponent/release-list-tile/release-list-tile.component.html
+++ b/src/app/music/mainComponent/release-list-tile/release-list-tile.component.html
@@ -6,8 +6,9 @@
             <release-list-thumbnail [release]="release"></release-list-thumbnail>
         </div>
         
-        <span class="viewAll-button" (click)="viewReleases()" [innerHTML]="musicContent.button1"></span>
     </div>
+    
+    <span class="viewAll-button" (click)="viewReleases()" [innerHTML]="musicContent.button1"></span>
     
 </div>
 


### PR DESCRIPTION
Further changes to make app more responsive for smaller devices.

Button location changes within the release list and podcast list tiles to prevent it being pushed all the way to the right on smaller screens. It now remains positioned beneath the list container.