### PR TITLE
Firefox font-size removed

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -4,11 +4,11 @@ html {
   font-size: 62.5%;
 }
 
-@-moz-document url-prefix() {
+/* @-moz-document url-prefix() {
   html {
       font-size: 71.5%;
   }
-}
+} */
   
 .wrapper {
   padding-top: 0;


### PR DESCRIPTION
Font size to target Firefox removed as not required, this results in all content being larger than it should.